### PR TITLE
Update DbalProducer.php

### DIFF
--- a/pkg/dbal/DbalProducer.php
+++ b/pkg/dbal/DbalProducer.php
@@ -66,7 +66,7 @@ class DbalProducer implements Producer
         ;
 
         $dbalMessage = [
-            'id' => Uuid::uuid4(),
+            'id' => Uuid::uuid4()->toString(),
             'published_at' => $publishedAt,
             'body' => $body,
             'headers' => JSON::encode($message->getHeaders()),


### PR DESCRIPTION
from this thread https://github.com/ramsey/uuid/issues/327 ramsey/uuid 4.1 introduced LazyUuidFromString object which is used over the original Uuid object

this causes conversions issues when using the objects, but can simply use toString() from UuidInterface to convert to actual guid when inserting